### PR TITLE
Disable to the force press in simulator when 'UseTrack Force' is enable

### DIFF
--- a/DebugHead/Classes/DebugHeadWindow.swift
+++ b/DebugHead/Classes/DebugHeadWindow.swift
@@ -110,7 +110,14 @@ final class DebugHeadWindow: UIWindow {
     
     addGestureRecognizer(panGestureRecognizer)
     addGestureRecognizer(tapGestureRecognizer)
+
+    // The force press gesture is recognized as normal tap gesture in simulator when 'UseTrack Force' is enable.
+    // So we disable to the force press gesture in the simulator.
+    //   Simulator's setting: Hardware -> Touch Pressure -> UseTrack Force ✔︎
+    #if TARGET_IPHONE_SIMULATOR
+    #else
     addGestureRecognizer(forcePressGestureRecognizer)
+    #endif
   }
   
   private static var bundle: Bundle {

--- a/DebugHead/Classes/DebugHeadWindow.swift
+++ b/DebugHead/Classes/DebugHeadWindow.swift
@@ -112,7 +112,7 @@ final class DebugHeadWindow: UIWindow {
     // The force press gesture is recognized as normal tap gesture in simulator when 'UseTrack Force' is enable.
     // So we disable to the force press gesture in the simulator.
     //   Simulator's setting: Hardware -> Touch Pressure -> UseTrack Force ✔︎
-    #if TARGET_IPHONE_SIMULATOR
+    #if targetEnvironment(simulator)
     #else
     let forcePressGestureRecognizer = FourcePressGestureRecognizer(target: self, action: #selector(fourcePressed))
     addGestureRecognizer(forcePressGestureRecognizer)

--- a/DebugHead/Classes/DebugHeadWindow.swift
+++ b/DebugHead/Classes/DebugHeadWindow.swift
@@ -134,11 +134,14 @@ final class DebugHeadWindow: UIWindow {
     let screenSize = UIScreen.main.bounds.size
     ratioCenter = CGPoint(x: center.x / screenSize.width, y: center.y / screenSize.height)
   }
-  
+
+  #if targetEnvironment(simulator)
+  #else
   @objc private func fourcePressed() {
     DebugHead.shared.remove()
   }
-  
+  #endif
+
   private func updateCenter() {
     let screenSize = UIScreen.main.bounds.size
     center = CGPoint(x: screenSize.width * ratioCenter.x, y: screenSize.height * ratioCenter.y)

--- a/DebugHead/Classes/DebugHeadWindow.swift
+++ b/DebugHead/Classes/DebugHeadWindow.swift
@@ -114,7 +114,7 @@ final class DebugHeadWindow: UIWindow {
     //   Simulator's setting: Hardware -> Touch Pressure -> UseTrack Force ✔︎
     #if targetEnvironment(simulator)
     #else
-    let forcePressGestureRecognizer = FourcePressGestureRecognizer(target: self, action: #selector(fourcePressed))
+    let forcePressGestureRecognizer = FourcePressGestureRecognizer(target: self, action: #selector(forcePressed))
     addGestureRecognizer(forcePressGestureRecognizer)
     #endif
   }
@@ -137,7 +137,7 @@ final class DebugHeadWindow: UIWindow {
 
   #if targetEnvironment(simulator)
   #else
-  @objc private func fourcePressed() {
+  @objc private func forcePressed() {
     DebugHead.shared.remove()
   }
   #endif

--- a/DebugHead/Classes/DebugHeadWindow.swift
+++ b/DebugHead/Classes/DebugHeadWindow.swift
@@ -106,8 +106,6 @@ final class DebugHeadWindow: UIWindow {
   private func prepareGestureRecognizers() {
     let panGestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(panned(_:)))
     let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(openDebugMenu))
-    let forcePressGestureRecognizer = FourcePressGestureRecognizer(target: self, action: #selector(fourcePressed))
-    
     addGestureRecognizer(panGestureRecognizer)
     addGestureRecognizer(tapGestureRecognizer)
 
@@ -116,6 +114,7 @@ final class DebugHeadWindow: UIWindow {
     //   Simulator's setting: Hardware -> Touch Pressure -> UseTrack Force ✔︎
     #if TARGET_IPHONE_SIMULATOR
     #else
+    let forcePressGestureRecognizer = FourcePressGestureRecognizer(target: self, action: #selector(fourcePressed))
     addGestureRecognizer(forcePressGestureRecognizer)
     #endif
   }


### PR DESCRIPTION
# Problem

The debug icon hides In some simulator when user touches the one.

# The cause

The force press gesture is recognized as normal tap gesture in simulator when 'UseTrack Force' is enable.

# Solution

I disabled to the force press gesture in the simulator.